### PR TITLE
fix(ENG-11542): use bt_semantic_release app token for release write-back

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,7 @@ jobs:
           app-id: ${{ vars.SEMANTIC_RELEASE_APP_ID }}
           private-key: ${{ secrets.SEMANTIC_RELEASE_APP_PRIVATE_KEY }}
           permission-contents: write
-          permission-issues: write
-          permission-pull-requests: write
+          permission-contents: write
 
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
           app-id: ${{ vars.SEMANTIC_RELEASE_APP_ID }}
           private-key: ${{ secrets.SEMANTIC_RELEASE_APP_PRIVATE_KEY }}
           permission-contents: write
-          permission-contents: write
 
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ jobs:
   tag:
     name: Tag repo
     runs-on: ubuntu-latest
+    environment: PROD
     permissions:
       contents: write
       packages: write
@@ -18,11 +19,22 @@ jobs:
           slack-api-token: ${{ secrets.SLACK_DUCKBOT_API_KEY }}
           channel: ${{ vars.SLACK_DUCKBOT_RELEASE_CHANNEL_ID }}
 
+      - name: Mint semantic-release app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ vars.SEMANTIC_RELEASE_APP_ID }}
+          private-key: ${{ secrets.SEMANTIC_RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.SEMANTIC_RELEASE_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Setup JDK version
         uses: actions/setup-java@v4
@@ -33,7 +45,7 @@ jobs:
 
       - name: Bump version and push tag
         id: tag-version
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@d28fa2ccfbd16e871a4bdf35e11b3ad1bd56c0c1 # v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: false
@@ -61,10 +73,10 @@ jobs:
           git commit -m "chore(release): updating version and changelog ${{ steps.tag-version.outputs.new_tag }} [skip ci]" || echo "Nothing to update"
 
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # master
         if: ${{ steps.tag-version.outputs.release_type != '' }}
         with:
-          github_token: ${{ secrets.SEMANTIC_RELEASE_PAT }}
+          github_token: ${{ steps.app-token.outputs.token }}
           branch: ${{ github.ref }}
 
       - name: Stop Deploy Message

--- a/build.gradle
+++ b/build.gradle
@@ -11,14 +11,17 @@ plugins {
 
 configurations.all {
     resolutionStrategy {
-        force 'io.netty:netty-handler:4.1.132.Final'
-        force 'io.netty:netty-codec-http2:4.1.132.Final'
-        force 'io.netty:netty-codec:4.1.132.Final'
-        force 'io.netty:netty-buffer:4.1.132.Final'
-        force 'io.netty:netty-common:4.1.132.Final'
-        force 'io.netty:netty-resolver:4.1.132.Final'
-        force 'io.netty:netty-transport:4.1.132.Final'
+        force 'io.netty:netty-handler:4.1.135.Final'
+        force 'io.netty:netty-codec-http2:4.1.135.Final'
+        force 'io.netty:netty-codec-http:4.1.135.Final'
+        force 'io.netty:netty-codec:4.1.135.Final'
+        force 'io.netty:netty-buffer:4.1.135.Final'
+        force 'io.netty:netty-common:4.1.135.Final'
+        force 'io.netty:netty-resolver:4.1.135.Final'
+        force 'io.netty:netty-transport:4.1.135.Final'
         force 'io.grpc:grpc-netty:1.58.0'
+
+        force 'io.opentelemetry:opentelemetry-api:1.62.0'
 
         force 'org.bouncycastle:bcpg-jdk18on:1.84'
         force 'org.bouncycastle:bcpkix-jdk18on:1.84'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -71,13 +71,15 @@ android {
 
 configurations.all {
     resolutionStrategy {
-        force 'io.netty:netty-codec-http2:4.1.132.Final'
-        force 'io.netty:netty-handler:4.1.132.Final'
-        force 'io.netty:netty-codec:4.1.132.Final'
-        force 'io.netty:netty-buffer:4.1.132.Final'
-        force 'io.netty:netty-common:4.1.132.Final'
-        force 'io.netty:netty-resolver:4.1.132.Final'
-        force 'io.netty:netty-transport:4.1.132.Final'
+        force 'io.netty:netty-codec-http2:4.1.135.Final'
+        force 'io.netty:netty-codec-http:4.1.135.Final'
+        force 'io.netty:netty-handler:4.1.135.Final'
+        force 'io.netty:netty-codec:4.1.135.Final'
+        force 'io.netty:netty-buffer:4.1.135.Final'
+        force 'io.netty:netty-common:4.1.135.Final'
+        force 'io.netty:netty-resolver:4.1.135.Final'
+        force 'io.netty:netty-transport:4.1.135.Final'
+        force 'io.opentelemetry:opentelemetry-api:1.62.0'
         force 'com.google.protobuf:protobuf-java:3.25.5'
         force 'org.bouncycastle:bcpg-jdk18on:1.84'
         force 'org.bouncycastle:bcpkix-jdk18on:1.84'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -67,8 +67,8 @@ android {
 
 configurations.all {
     resolutionStrategy {
-        force 'io.netty:netty-codec-http2:4.1.132.Final'
-        force 'io.netty:netty-handler:4.1.132.Final'
+        force 'io.netty:netty-codec-http2:4.1.135.Final'
+        force 'io.netty:netty-handler:4.1.135.Final'
         force 'com.google.protobuf:protobuf-java:3.25.5'
         force 'com.google.protobuf:protobuf-javalite:4.28.2'
         force 'com.nimbusds:nimbus-jose-jwt:9.37.2'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -69,6 +69,7 @@ configurations.all {
     resolutionStrategy {
         force 'io.netty:netty-codec-http2:4.1.135.Final'
         force 'io.netty:netty-handler:4.1.135.Final'
+        force 'io.opentelemetry:opentelemetry-api:1.62.0'
         force 'com.google.protobuf:protobuf-java:3.25.5'
         force 'com.google.protobuf:protobuf-javalite:4.28.2'
         force 'com.nimbusds:nimbus-jose-jwt:9.37.2'


### PR DESCRIPTION
## Description
Completes the semantic-release PAT → GitHub App migration for android-threeds (missed by ENG-11425). The `release.yml` `tag` job used the bare `SEMANTIC_RELEASE_PAT` for checkout and the master `[skip ci]` write-back.

- `tag` job now declares `environment: PROD` (so the master-restricted `SEMANTIC_RELEASE_APP_PRIVATE_KEY` resolves). Existing `permissions: contents/packages: write` retained for the `GITHUB_TOKEN`-based tag creation + GH Packages publish (unchanged).
- Mints a `bt_semantic_release` app token (least-privilege `permission-contents/issues/pull-requests: write`) for the checkout `token:` and the `ad-m/github-push-action` `github_token:`.
- `persist-credentials: false`; SHA-pinned the token-receiving actions (`checkout`, `ad-m/github-push-action`) and the tag action.

**Paired with** github-repository-management#454 (provisions branch protection + bypass + prod-env app key for this repo).

### Rollout order (do not merge alone)
1. Apply github-repository-management#454.
2. `gh api -X DELETE repos/Basis-Theory/android-threeds/branches/master/protection`.
3. Merge this PR.
4. Validate a real release.

## Business Impact
- Minimal — removes a user-tied PAT from the release flow.

## Testing required outside of automated testing?
- [ ] Not Applicable — validate a real release end-to-end after the rollout steps.

### Screenshots (if appropriate):
- [x] Not Applicable

## Rollback / Rollforward Procedure
- [x] Roll Forward
- [ ] Roll Back

## Documentation
ENG-11542; pattern in github-repository-management docs/github-app-token-architecture.md.

## Reviewer Checklist
- [ ] Description of Change
- [ ] Description of Business Impact
- [ ] Description of outside testing if applicable
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change