### PR TITLE
feat: emit 3DS challenge lifecycle telemetry to Datadog

### DIFF
--- a/lib/src/main/java/com/basistheory/threeds/service/Telemetry.kt
+++ b/lib/src/main/java/com/basistheory/threeds/service/Telemetry.kt
@@ -1,0 +1,50 @@
+package com.basistheory.threeds.service
+
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import org.json.JSONObject
+import java.io.IOException
+
+internal object Telemetry {
+    private const val INTAKE_URL =
+        "https://http-intake.logs.datadoghq.com/v1/input/pubb96b84a13912504f4354f2d794ea4fab"
+
+    private val client = OkHttpClient()
+    private val jsonMediaType = "application/json".toMediaType()
+
+    fun send(
+        event: String,
+        sessionId: String,
+        apiKey: String,
+        attributes: Map<String, String> = emptyMap()
+    ) {
+        val payload = JSONObject().apply {
+            put("application", "3ds-android")
+            put("ddsource", "3ds-android")
+            put("service", "3ds-android")
+            put("event", event)
+            put("sessionId", sessionId)
+            put("apiKey", apiKey)
+            put("message", event)
+            attributes.forEach { (key, value) -> put(key, value) }
+        }
+
+        val request = Request.Builder()
+            .url(INTAKE_URL)
+            .post(payload.toString().toRequestBody(jsonMediaType))
+            .build()
+
+        client.newCall(request).enqueue(object : Callback {
+            override fun onFailure(call: Call, e: IOException) {}
+
+            override fun onResponse(call: Call, response: Response) {
+                response.close()
+            }
+        })
+    }
+}

--- a/lib/src/main/java/com/basistheory/threeds/service/ThreeDSService.kt
+++ b/lib/src/main/java/com/basistheory/threeds/service/ThreeDSService.kt
@@ -318,6 +318,8 @@ class ThreeDSService(
                     purchaseAmount = authenticationResponse.purchaseAmount
                 )
 
+                Telemetry.send("challenge.started", sessionId, apiKey)
+
                 transaction!!.doChallenge(
                     currentActivity = activity,
                     challengeParameters = params,
@@ -326,6 +328,11 @@ class ThreeDSService(
                         override fun completed(completionEvent: CompletionEvent?) {
                             val transactionStatus =
                                 transactionStatusMap[completionEvent?.getTransactionStatus()]
+
+                            Telemetry.send(
+                                "challenge.completed", sessionId, apiKey,
+                                mapOf("authenticationStatus" to (transactionStatus ?: ""))
+                            )
 
                             transactionStatus
                                 ?.let {
@@ -343,11 +350,13 @@ class ThreeDSService(
                         }
 
                         override fun cancelled() {
+                            Telemetry.send("challenge.abandoned", sessionId, apiKey)
                             closeTransaction()
                             onFailure(ChallengeResponse(sessionId, transactionStatusMap["N"]!!, "Challenge cancelled"))
                         }
 
                         override fun timedout() {
+                            Telemetry.send("challenge.timed_out", sessionId, apiKey)
                             closeTransaction()
                             onFailure(ChallengeResponse(sessionId, transactionStatusMap["N"]!!, "Challenge timed out"))
                         }


### PR DESCRIPTION
## What
Add a Datadog telemetry sink (OkHttp) and emit `challenge.started` / `challenge.completed` / `challenge.abandoned` (cancelled) / `challenge.timed_out` from the challenge callbacks (`service:3ds-android`), tagged with the public apiKey — so challenge abandonment is observable in real time.

## Note
Not built locally. Please confirm CI build.