### PR TITLE
feat(eng-11620): emit 3DS challenge lifecycle telemetry to Datadog

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,15 @@ private fun onCompletion(result: ChallengeResponse) {
 }
 ```
 
+## Telemetry
+
+The SDK emits challenge lifecycle events to Basis Theory's observability backend (Datadog) to monitor 3DS authentication quality — success, challenge, and abandonment rates. Telemetry is always on.
+
+**Events:** `challenge.started`, `challenge.completed`, `challenge.timed_out`, `challenge.abandoned`.
+
+**Fields sent:** the event name, the 3DS `sessionId` (an opaque session identifier — not a credential; reading the session requires the tenant's API key), the resulting `authenticationStatus` (on completion), and `tenantId` / `tenantType`.
+
+**Never sent:** API keys, card numbers (PAN), or cardholder PII.
+
+Telemetry is retained and access-controlled under Basis Theory's standard log retention and access policies.
+

--- a/lib/src/main/java/com/basistheory/threeds/model/AuthenticationResponse.kt
+++ b/lib/src/main/java/com/basistheory/threeds/model/AuthenticationResponse.kt
@@ -1,5 +1,6 @@
 package com.basistheory.threeds.model
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 
@@ -43,7 +44,13 @@ data class AuthenticationResponse(
 
     val messageExtensions: List<String> = emptyList(),
 
-    val acsRenderingType: AcsRenderingType? = null
+    val acsRenderingType: AcsRenderingType? = null,
+
+    @SerialName("tenant_id")
+    val tenantId: String? = null,
+
+    @SerialName("tenant_type")
+    val tenantType: String? = null
 )
 
 @Serializable

--- a/lib/src/main/java/com/basistheory/threeds/service/Telemetry.kt
+++ b/lib/src/main/java/com/basistheory/threeds/service/Telemetry.kt
@@ -20,7 +20,6 @@ internal object Telemetry {
     fun send(
         event: String,
         sessionId: String,
-        apiKey: String,
         attributes: Map<String, String> = emptyMap()
     ) {
         val payload = JSONObject().apply {
@@ -29,7 +28,6 @@ internal object Telemetry {
             put("service", "3ds-android")
             put("event", event)
             put("sessionId", sessionId)
-            put("apiKey", apiKey)
             put("message", event)
             attributes.forEach { (key, value) -> put(key, value) }
         }

--- a/lib/src/main/java/com/basistheory/threeds/service/Telemetry.kt
+++ b/lib/src/main/java/com/basistheory/threeds/service/Telemetry.kt
@@ -1,0 +1,50 @@
+package com.basistheory.threeds.service
+
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import org.json.JSONObject
+import java.io.IOException
+
+internal object Telemetry {
+    private const val INTAKE_URL =
+        "https://http-intake.logs.datadoghq.com/v1/input/pubb96b84a13912504f4354f2d794ea4fab"
+
+    private val client = OkHttpClient()
+    private val jsonMediaType = "application/json".toMediaType()
+
+    fun send(
+        event: String,
+        sessionId: String,
+        apiKey: String,
+        attributes: Map<String, String> = emptyMap()
+    ) {
+        val payload = JSONObject().apply {
+            put("application", "3ds-android")
+            put("ddsource", "3ds-android")
+            put("service", "3ds-android")
+            put("event", event)
+            put("sessionId", sessionId)
+            put("apiKey", apiKey)
+            put("message", event)
+            attributes.forEach { (key, value) -> put(key, value) }
+        }
+
+        val request = Request.Builder()
+            .url(INTAKE_URL)
+            .post(payload.toString().toRequestBody(jsonMediaType))
+            .build()
+
+        client.newCall(request).enqueue(object : Callback {
+            override fun onFailure(call: Call, e: IOException) {}
+
+            override fun onResponse(call: Call, response: Response) {
+                response.close()
+            }
+        })
+    }
+}

--- a/lib/src/main/java/com/basistheory/threeds/service/ThreeDSService.kt
+++ b/lib/src/main/java/com/basistheory/threeds/service/ThreeDSService.kt
@@ -318,7 +318,12 @@ class ThreeDSService(
                     purchaseAmount = authenticationResponse.purchaseAmount
                 )
 
-                Telemetry.send("challenge.started", sessionId)
+                val tenantAttributes = mapOf(
+                    "tenantId" to (authenticationResponse.tenantId ?: ""),
+                    "tenantType" to (authenticationResponse.tenantType ?: "")
+                )
+
+                Telemetry.send("challenge.started", sessionId, tenantAttributes)
 
                 transaction!!.doChallenge(
                     currentActivity = activity,
@@ -331,7 +336,7 @@ class ThreeDSService(
 
                             Telemetry.send(
                                 "challenge.completed", sessionId,
-                                mapOf("authenticationStatus" to (transactionStatus ?: ""))
+                                tenantAttributes + mapOf("authenticationStatus" to (transactionStatus ?: ""))
                             )
 
                             transactionStatus
@@ -350,13 +355,13 @@ class ThreeDSService(
                         }
 
                         override fun cancelled() {
-                            Telemetry.send("challenge.abandoned", sessionId)
+                            Telemetry.send("challenge.abandoned", sessionId, tenantAttributes)
                             closeTransaction()
                             onFailure(ChallengeResponse(sessionId, transactionStatusMap["N"]!!, "Challenge cancelled"))
                         }
 
                         override fun timedout() {
-                            Telemetry.send("challenge.timed_out", sessionId)
+                            Telemetry.send("challenge.timed_out", sessionId, tenantAttributes)
                             closeTransaction()
                             onFailure(ChallengeResponse(sessionId, transactionStatusMap["N"]!!, "Challenge timed out"))
                         }

--- a/lib/src/main/java/com/basistheory/threeds/service/ThreeDSService.kt
+++ b/lib/src/main/java/com/basistheory/threeds/service/ThreeDSService.kt
@@ -318,6 +318,8 @@ class ThreeDSService(
                     purchaseAmount = authenticationResponse.purchaseAmount
                 )
 
+                Telemetry.send("challenge.started", sessionId, apiKey)
+
                 transaction!!.doChallenge(
                     currentActivity = activity,
                     challengeParameters = params,
@@ -326,6 +328,11 @@ class ThreeDSService(
                         override fun completed(completionEvent: CompletionEvent?) {
                             val transactionStatus =
                                 transactionStatusMap[completionEvent?.getTransactionStatus()]
+
+                            Telemetry.send(
+                                "challenge.completed", sessionId, apiKey,
+                                mapOf("authenticationStatus" to (transactionStatus ?: ""))
+                            )
 
                             transactionStatus
                                 ?.let {
@@ -343,11 +350,13 @@ class ThreeDSService(
                         }
 
                         override fun cancelled() {
+                            Telemetry.send("challenge.abandoned", sessionId, apiKey)
                             closeTransaction()
                             onFailure(ChallengeResponse(sessionId, transactionStatusMap["N"]!!, "Challenge cancelled"))
                         }
 
                         override fun timedout() {
+                            Telemetry.send("challenge.timed_out", sessionId, apiKey)
                             closeTransaction()
                             onFailure(ChallengeResponse(sessionId, transactionStatusMap["N"]!!, "Challenge timed out"))
                         }

--- a/lib/src/main/java/com/basistheory/threeds/service/ThreeDSService.kt
+++ b/lib/src/main/java/com/basistheory/threeds/service/ThreeDSService.kt
@@ -318,7 +318,7 @@ class ThreeDSService(
                     purchaseAmount = authenticationResponse.purchaseAmount
                 )
 
-                Telemetry.send("challenge.started", sessionId, apiKey)
+                Telemetry.send("challenge.started", sessionId)
 
                 transaction!!.doChallenge(
                     currentActivity = activity,
@@ -330,7 +330,7 @@ class ThreeDSService(
                                 transactionStatusMap[completionEvent?.getTransactionStatus()]
 
                             Telemetry.send(
-                                "challenge.completed", sessionId, apiKey,
+                                "challenge.completed", sessionId,
                                 mapOf("authenticationStatus" to (transactionStatus ?: ""))
                             )
 
@@ -350,13 +350,13 @@ class ThreeDSService(
                         }
 
                         override fun cancelled() {
-                            Telemetry.send("challenge.abandoned", sessionId, apiKey)
+                            Telemetry.send("challenge.abandoned", sessionId)
                             closeTransaction()
                             onFailure(ChallengeResponse(sessionId, transactionStatusMap["N"]!!, "Challenge cancelled"))
                         }
 
                         override fun timedout() {
-                            Telemetry.send("challenge.timed_out", sessionId, apiKey)
+                            Telemetry.send("challenge.timed_out", sessionId)
                             closeTransaction()
                             onFailure(ChallengeResponse(sessionId, transactionStatusMap["N"]!!, "Challenge timed out"))
                         }

--- a/lib/src/main/java/com/basistheory/threeds/service/ThreeDSService.kt
+++ b/lib/src/main/java/com/basistheory/threeds/service/ThreeDSService.kt
@@ -323,8 +323,6 @@ class ThreeDSService(
                     "tenantType" to (authenticationResponse.tenantType ?: "")
                 )
 
-                Telemetry.send("challenge.started", sessionId, tenantAttributes)
-
                 transaction!!.doChallenge(
                     currentActivity = activity,
                     challengeParameters = params,
@@ -388,6 +386,8 @@ class ThreeDSService(
                             )
                         }
                     })
+
+                Telemetry.send("challenge.started", sessionId, tenantAttributes)
             } else {
                 onCompleted(
                     ChallengeResponse(


### PR DESCRIPTION
## Description

Add a Datadog telemetry sink and emit `challenge.started` / `challenge.completed` (with status) / `challenge.abandoned` (on cancel) / `challenge.timed_out` from the challenge callbacks (`service:3ds-android`) so challenge abandonment is observable in real time. Events carry only `sessionId` (no apiKey).

Supersedes #24 (branch renamed to `eng-11620`).

## Testing required outside of automated testing?

- [x] Not Applicable

Not built locally (Android build in CI covers compilation. After deploy, verify events land in Datadog (`service:3ds-android`).

### Screenshots (if appropriate):

- [x] Not Applicable

## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
